### PR TITLE
Login/email Decoupling

### DIFF
--- a/tests/test_user_broker/stubs/create_new_user.json
+++ b/tests/test_user_broker/stubs/create_new_user.json
@@ -1,76 +1,128 @@
 [
   {
-      "predicates":[
-         {
-            "equals":{
-               "method":"POST",
-               "path":"/api/v1/users"
+    "predicates": [
+      {
+        "equals": {
+          "method": "POST",
+          "path": "/api/v1/users"
+        }
+      },
+      {
+        "contains": {
+          "body": "different-email@aol.com"
+        }
+      }
+    ],
+    "responses": [
+      {
+        "is": {
+          "statusCode": 200,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {
+            "id": "00002",
+            "status": "STAGED",
+            "created": "2013-07-02T21:36:25.344Z",
+            "activated": null,
+            "statusChanged": null,
+            "lastLogin": null,
+            "lastUpdated": "2013-07-02T21:36:25.344Z",
+            "passwordChanged": null,
+            "profile": {
+              "firstName": "Gary",
+              "lastName": "Garrison",
+              "email": "some-email@aol.com",
+              "login": "different-email@aol.com",
+              "mobilePhone": "234-567-8901"
+            },
+            "credentials": {
+              "provider": {
+                "type": "OKTA",
+                "name": "OKTA"
+              }
+            },
+            "_links": {
+              "activate": {
+                "href": "https://your-domain.okta.com/api/v1/users/00ub0oNGTSWTBKOLGLNR/lifecycle/activate"
+              }
             }
-         }
-      ],
-      "responses":[
-         {
-            "is":{
-               "statusCode":200,
-               "headers":{
-                  "Content-Type":"application/json"
-               },
-               "body": {
-                   "id":"00002",
-                   "status":"STAGED",
-                   "created":"2013-07-02T21:36:25.344Z",
-                   "activated":null,
-                   "statusChanged":null,
-                   "lastLogin":null,
-                   "lastUpdated":"2013-07-02T21:36:25.344Z",
-                   "passwordChanged":null,
-                   "profile":{
-                      "firstName":"Gary",
-                      "lastName":"Garrison",
-                      "email":"gary@aol.com",
-                      "login":"gary@aol.com",
-                      "mobilePhone":"234-567-8901"
-                   },
-                   "credentials":{
-                      "provider":{
-                         "type":"OKTA",
-                         "name":"OKTA"
-                      }
-                   },
-                   "_links":{
-                      "activate":{
-                         "href":"https://your-domain.okta.com/api/v1/users/00ub0oNGTSWTBKOLGLNR/lifecycle/activate"
-                      }
-                   }
-               }
-            }
-         }
-      ]
-   },
-
+          }
+        }
+      }
+    ]
+  },
   {
-      "predicates":[
-         {
-            "equals":{
-               "method":"GET",
-               "path":"/api/v1/users",
-                "query":{
-                  "filter": "profile.login eq \"gary@aol.com\"",
-                  "limit": "1"
-                }
+    "predicates": [
+      {
+        "equals": {
+          "method": "POST",
+          "path": "/api/v1/users"
+        }
+      }
+    ],
+    "responses": [
+      {
+        "is": {
+          "statusCode": 200,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": {
+            "id": "00002",
+            "status": "STAGED",
+            "created": "2013-07-02T21:36:25.344Z",
+            "activated": null,
+            "statusChanged": null,
+            "lastLogin": null,
+            "lastUpdated": "2013-07-02T21:36:25.344Z",
+            "passwordChanged": null,
+            "profile": {
+              "firstName": "Gary",
+              "lastName": "Garrison",
+              "email": "gary@aol.com",
+              "login": "gary@aol.com",
+              "mobilePhone": "234-567-8901"
+            },
+            "credentials": {
+              "provider": {
+                "type": "OKTA",
+                "name": "OKTA"
+              }
+            },
+            "_links": {
+              "activate": {
+                "href": "https://your-domain.okta.com/api/v1/users/00ub0oNGTSWTBKOLGLNR/lifecycle/activate"
+              }
             }
-         }
-      ],
-      "responses":[
-         {
-            "is":{
-               "statusCode":404,
-               "headers":{
-                  "Content-Type":"application/json"
-               },
-               "body": []
-            }
-         }
-      ]
-   }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "predicates": [
+      {
+        "equals": {
+          "method": "GET",
+          "path": "/api/v1/users",
+          "query": {
+            "filter": "profile.login eq \"gary@aol.com\"",
+            "limit": "1"
+          }
+        }
+      }
+    ],
+    "responses": [
+      {
+        "is": {
+          "statusCode": 404,
+          "headers": {
+            "Content-Type": "application/json"
+          },
+          "body": []
+        }
+      }
+    ]
+  }
 ]

--- a/tests/test_user_broker/test_user_broker.py
+++ b/tests/test_user_broker/test_user_broker.py
@@ -19,6 +19,10 @@ user_five = {
 user_six = {
     'id': None, 'login': 'factors-fail@aol.com', 'email': "factors-fail@aol.com", 'mobile_phone': "345-6789-0123",
     'first_name': 'A', 'last_name': 'A'}
+user_seven = {
+    'id': None, 'login': 'different-email@aol.com', 'email': 'some-email@aol.com', 'mobile_phone': '345-6789-0123',
+    'first_name': 'A', 'last_name': 'A'
+}
 
 
 class TestUserBroker(unittest.TestCase):
@@ -38,9 +42,17 @@ class TestUserBroker(unittest.TestCase):
         self.setup_imposter('create_new_user.json')
         user = self.broker.create_user(user_two)
         self.assertIsNotNone(user)
-        self.assertEqual(user['id'], "00002")
+        self.assertEqual(user['id'], '00002')
         self.assertEqual(user['login'], user_two.get('login'))
         self.assertEqual(user['mobile_phone'], user_two.get('mobile_phone'))
+
+    def test_create_user_with_differing_login_email(self):
+        self.setup_imposter('create_new_user.json')
+        user = self.broker.create_user(user_seven)
+        self.assertIsNotNone(user)
+        self.assertEqual(user['id'], '00002')
+        self.assertEqual(user_seven['login'], user['login'])
+        self.assertEqual(user_seven['email'], user['email'])
 
     def test_update_existing_user_with_id(self):
         self.setup_imposter('update_existing_user.json')

--- a/theoktany/auth_client.py
+++ b/theoktany/auth_client.py
@@ -82,7 +82,7 @@ class OktaFactors(object):
         assert pass_code
 
         def v(factor_id):
-            route = '/api/v1/users/{}/factors/{}/lifecycle/activate'.format(user_id, factor_id)
+            route = '/api/v1/users/{}/factors/{}/lifecycle/activate?sendEmail=false'.format(user_id, factor_id)
             # noinspection PyArgumentList
             return _validate(*self._api_client.post(route, data=serialize({'passCode': pass_code})))
 

--- a/theoktany/user_broker.py
+++ b/theoktany/user_broker.py
@@ -20,8 +20,10 @@ class UserBroker:
         if 'last_name' in user_data:
             user_dict['profile']['lastName'] = user_data['last_name']
         if 'email' in user_data:
-            user_dict['profile']['login'] = user_data['email']
             user_dict['profile']['email'] = user_data['email']
+            user_dict['profile']['login'] = user_data['email']
+        if 'login' in user_data:
+            user_dict['profile']['login'] = user_data['login']
 
         return json.dumps(user_dict)
 
@@ -30,6 +32,7 @@ class UserBroker:
         user_dict = {
             'id': user_data['id'],
             'login': user_data['profile']['login'],
+            'email': user_data['profile']['email'],
             'mobile_phone': user_data['profile']['mobilePhone'],
             'factors': [],
         }


### PR DESCRIPTION
The user `login` and `email` fields have been treated as being identical. Due to OKTA's insistence on sending users emails and following OKTA's advice, this allows the `login` and `email` fields to be set independently of each other.

`login` will default to the value of `email` if not provided, so this is non-breaking. This will **NOT** change the behavior of web-auth.

Ok, ok, fine, the flags *are* documented, I just didn't notice because it wasn't really clear. But now I know what to look for.
![screen shot 2015-12-29 at 4 00 38 pm](https://cloud.githubusercontent.com/assets/5742331/12042066/5fb446de-ae45-11e5-8fb4-b97ab7a0bfa1.png)

I imagine that our contact at OKTA is starting to get a bit annoyed at us since it is clearly in the documentation...